### PR TITLE
Update fee token data for carbon-1 chain

### DIFF
--- a/packages/chain-registry/src/chains.ts
+++ b/packages/chain-registry/src/chains.ts
@@ -2460,9 +2460,9 @@ const chains: Chain[] = [
         {
           denom: 'swth',
           fixed_min_gas_price: 0,
-          low_gas_price: 769.23077,
-          average_gas_price: 769.23077,
-          high_gas_price: 769.230774
+          low_gas_price: 1,
+          average_gas_price: 1.5,
+          high_gas_price: 2
         }
       ]
     },


### PR DESCRIPTION
Hi admins, there is an error in the gas price data for carbon-1 chain, which causes the tx fees to be displayed wrongly on the Leap wallet confirmation dialog. For example, in the screenshot below, the transaction charges should be `1 SWTH` instead of `769.23077 SWTH`.
<img width="402" alt="Screenshot 2023-01-10 at 6 03 28 PM" src="https://user-images.githubusercontent.com/65583522/211699512-bbfc0109-06c6-4bfa-b6f2-cf001a720dc9.png">

While this does not affect the final tx fee amount deducted, it might cause confusion among our users when approving transactions with Leap wallet, hence we seek your assistance in updating the gas prices by merging in this PR. Thank you for your kind attention!