### PR TITLE
force coin gecko IDs to be undefined

### DIFF
--- a/packages/keplr/src/index.ts
+++ b/packages/keplr/src/index.ts
@@ -105,18 +105,14 @@ export const chainRegistryChainToKeplr = (
     .filter((currency) => feeDenoms.includes(currency.coinMinimalDenom))
     .map((feeCurrency) => {
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
-        return {
-          ...feeCurrency,
-          coinGeckoId: feeCurrency.coinGeckoId || undefined
-        }
+        return feeCurrency
 
 
       // has gas
       const gasPriceStep = gasPriceSteps[feeCurrency.coinMinimalDenom];
       return {
         ...feeCurrency,
-        gasPriceStep,
-        coinGeckoId: feeCurrency.coinGeckoId || undefined
+        gasPriceStep
       };
     });
 
@@ -125,17 +121,13 @@ export const chainRegistryChainToKeplr = (
     .filter((currency) => stakeCurrency.coinDenom === currency.coinDenom)
     .map((feeCurrency) => {
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
-        return {
-          ...feeCurrency,
-          coinGeckoId: feeCurrency.coinGeckoId || undefined
-        };
+        return feeCurrency
 
       // has gas
       const gasPriceStep = gasPriceSteps[feeCurrency.coinMinimalDenom];
       return {
         ...feeCurrency,
-        gasPriceStep,
-        coinGeckoId: feeCurrency.coinGeckoId || undefined
+        gasPriceStep
       };
     });
 

--- a/packages/keplr/src/index.ts
+++ b/packages/keplr/src/index.ts
@@ -107,7 +107,6 @@ export const chainRegistryChainToKeplr = (
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
         return feeCurrency;
 
-
       // has gas
       const gasPriceStep = gasPriceSteps[feeCurrency.coinMinimalDenom];
       return {

--- a/packages/keplr/src/index.ts
+++ b/packages/keplr/src/index.ts
@@ -105,7 +105,7 @@ export const chainRegistryChainToKeplr = (
     .filter((currency) => feeDenoms.includes(currency.coinMinimalDenom))
     .map((feeCurrency) => {
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
-        return feeCurrency
+        return feeCurrency;
 
 
       // has gas
@@ -121,7 +121,7 @@ export const chainRegistryChainToKeplr = (
     .filter((currency) => stakeCurrency.coinDenom === currency.coinDenom)
     .map((feeCurrency) => {
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
-        return feeCurrency
+        return feeCurrency;
 
       // has gas
       const gasPriceStep = gasPriceSteps[feeCurrency.coinMinimalDenom];

--- a/packages/keplr/src/index.ts
+++ b/packages/keplr/src/index.ts
@@ -91,7 +91,7 @@ export const chainRegistryChainToKeplr = (
       coinDecimals: currency.denom_units.filter(
         (denomUnit: { denom: string }) => denomUnit.denom === currency.display
       )[0]?.exponent,
-      coinGeckoId: currency.coingecko_id,
+      coinGeckoId: currency.coingecko_id || undefined,
       coinImageUrl: currency.logo_URIs?.svg ?? currency.logo_URIs?.png
     };
   });
@@ -105,13 +105,18 @@ export const chainRegistryChainToKeplr = (
     .filter((currency) => feeDenoms.includes(currency.coinMinimalDenom))
     .map((feeCurrency) => {
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
-        return feeCurrency;
+        return {
+          ...feeCurrency,
+          coinGeckoId: feeCurrency.coinGeckoId || undefined
+        }
+
 
       // has gas
       const gasPriceStep = gasPriceSteps[feeCurrency.coinMinimalDenom];
       return {
         ...feeCurrency,
-        gasPriceStep
+        gasPriceStep,
+        coinGeckoId: feeCurrency.coinGeckoId || undefined
       };
     });
 

--- a/packages/keplr/src/index.ts
+++ b/packages/keplr/src/index.ts
@@ -125,13 +125,17 @@ export const chainRegistryChainToKeplr = (
     .filter((currency) => stakeCurrency.coinDenom === currency.coinDenom)
     .map((feeCurrency) => {
       if (!gasPriceSteps?.hasOwnProperty(feeCurrency.coinMinimalDenom))
-        return feeCurrency;
+        return {
+          ...feeCurrency,
+          coinGeckoId: feeCurrency.coinGeckoId || undefined
+        };
 
       // has gas
       const gasPriceStep = gasPriceSteps[feeCurrency.coinMinimalDenom];
       return {
         ...feeCurrency,
-        gasPriceStep
+        gasPriceStep,
+        coinGeckoId: feeCurrency.coinGeckoId || undefined
       };
     });
 


### PR DESCRIPTION
Currently the `chainRegistryChainToKeplr` returns currencies with `coinGeckoId: ""`. This leads to errors when doing things like adding chains to Kepler.

Context here https://github.com/chainapsis/keplr-wallet/issues/657 if you're interested. 