### PR TITLE
fix: keplr cleanVer containing repo

### DIFF
--- a/packages/keplr/src/index.ts
+++ b/packages/keplr/src/index.ts
@@ -9,6 +9,10 @@ const getExplr = (chain: Chain): string => chain.explorers?.[0]?.url ?? '';
 
 const cleanVer = (ver: string) => {
   if (!semver.valid(ver)) {
+    // try to split by @ for repo@version
+    ver = ver.split("@").pop()
+    if (semver.valid(ver)) return ver
+    
     const spaces = ver.split('.').length;
     switch (spaces) {
       case 1:


### PR DESCRIPTION
Fixes https://github.com/cosmology-tech/chain-registry/issues/41

The error occurs in `cleanVer()` as there is a prerelease tag and it is not a valid semver when there is the repo prefix `repo@version`.

Failing case:

```
"cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
```

This is quite a naive solution, but should address the current problem.